### PR TITLE
Add bookmark export utilities for major browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/browser_exporter/chrome.py
+++ b/browser_exporter/chrome.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from .utils import chrome_json_to_html, load_chrome_bookmark_json
+
+
+def _default_chrome_path(profile: str = "Default") -> Path:
+    system = os.sys.platform
+    home = Path.home()
+    if system.startswith("win"):
+        base = Path(os.environ.get("LOCALAPPDATA", home / "AppData/Local"))
+        return base / "Google/Chrome/User Data" / profile / "Bookmarks"
+    if system == "darwin":
+        return home / "Library/Application Support/Google/Chrome" / profile / "Bookmarks"
+    # Assume Linux
+    return home / ".config/google-chrome" / profile / "Bookmarks"
+
+
+def export_bookmarks(output_dir: Path, profile: str = "Default") -> Path:
+    """Export Chrome bookmarks to output_dir. Returns path to HTML file."""
+    src = _default_chrome_path(profile)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not src.exists():
+        raise FileNotFoundError(f"Chrome bookmarks not found at {src}")
+
+    dst_native = output_dir / "chrome_bookmarks.json"
+    shutil.copy2(src, dst_native)
+
+    data = load_chrome_bookmark_json(dst_native)
+    html = chrome_json_to_html(data)
+    dst_html = output_dir / "chrome_bookmarks.html"
+    dst_html.write_text(html, encoding="utf-8")
+    return dst_html

--- a/browser_exporter/cli.py
+++ b/browser_exporter/cli.py
@@ -1,0 +1,35 @@
+import argparse
+from pathlib import Path
+
+from . import chrome, edge, firefox
+
+
+BROWSERS = {
+    "chrome": chrome.export_bookmarks,
+    "edge": edge.export_bookmarks,
+    "firefox": firefox.export_bookmarks,
+}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Export browser bookmarks")
+    parser.add_argument("output", type=Path, help="Directory to save exported bookmarks")
+    parser.add_argument(
+        "--browsers",
+        nargs="+",
+        choices=BROWSERS.keys(),
+        default=list(BROWSERS.keys()),
+        help="Browsers to export",
+    )
+    args = parser.parse_args(argv)
+
+    for name in args.browsers:
+        try:
+            BROWSERS[name](args.output)
+            print(f"Exported {name} bookmarks to {args.output}")
+        except FileNotFoundError as exc:
+            print(f"{name}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/browser_exporter/edge.py
+++ b/browser_exporter/edge.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+from pathlib import Path
+
+from .utils import chrome_json_to_html, load_chrome_bookmark_json
+
+
+def _default_edge_path(profile: str = "Default") -> Path:
+    system = os.sys.platform
+    home = Path.home()
+    if system.startswith("win"):
+        base = Path(os.environ.get("LOCALAPPDATA", home / "AppData/Local"))
+        return base / "Microsoft/Edge/User Data" / profile / "Bookmarks"
+    if system == "darwin":
+        return home / "Library/Application Support/Microsoft Edge" / profile / "Bookmarks"
+    # Assume Linux
+    return home / ".config/microsoft-edge" / profile / "Bookmarks"
+
+
+def export_bookmarks(output_dir: Path, profile: str = "Default") -> Path:
+    src = _default_edge_path(profile)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not src.exists():
+        raise FileNotFoundError(f"Edge bookmarks not found at {src}")
+
+    dst_native = output_dir / "edge_bookmarks.json"
+    shutil.copy2(src, dst_native)
+
+    data = load_chrome_bookmark_json(dst_native)
+    html = chrome_json_to_html(data)
+    dst_html = output_dir / "edge_bookmarks.html"
+    dst_html.write_text(html, encoding="utf-8")
+    return dst_html

--- a/browser_exporter/firefox.py
+++ b/browser_exporter/firefox.py
@@ -1,0 +1,83 @@
+import configparser
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional
+
+
+def _profiles_root() -> Path:
+    system = os.sys.platform
+    home = Path.home()
+    if system.startswith("win"):
+        return Path(os.environ.get("APPDATA", home / "AppData/Roaming")) / "Mozilla/Firefox"
+    if system == "darwin":
+        return home / "Library/Application Support/Firefox"
+    return home / ".mozilla/firefox"
+
+
+def _parse_profiles() -> Dict[str, Path]:
+    root = _profiles_root()
+    ini = root / "profiles.ini"
+    cfg = configparser.ConfigParser()
+    profiles: Dict[str, Path] = {}
+    if ini.exists():
+        cfg.read(ini)
+        for section in cfg.sections():
+            if section.startswith("Profile"):
+                name = cfg.get(section, "Name", fallback=None)
+                path = cfg.get(section, "Path", fallback=None)
+                if name and path:
+                    profiles[name] = root / path
+    return profiles
+
+
+def _default_profile() -> Path:
+    profiles = _parse_profiles()
+    if not profiles:
+        raise FileNotFoundError("No Firefox profiles found")
+    # Pick first profile
+    return next(iter(profiles.values()))
+
+
+def export_bookmarks(output_dir: Path, profile: Optional[str] = None) -> Path:
+    profiles = _parse_profiles()
+    src_dir = profiles.get(profile) if profile else _default_profile()
+    places = Path(src_dir) / "places.sqlite"
+    if not places.exists():
+        raise FileNotFoundError(f"places.sqlite not found in {src_dir}")
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    dst_native = output_dir / "firefox_places.sqlite"
+    shutil.copy2(places, dst_native)
+
+    # Extract basic bookmarks (without hierarchy)
+    con = sqlite3.connect(dst_native)
+    cur = con.cursor()
+    cur.execute(
+        """
+        SELECT moz_places.url, moz_bookmarks.title
+        FROM moz_bookmarks
+        JOIN moz_places ON moz_bookmarks.fk = moz_places.id
+        WHERE moz_bookmarks.type = 1 AND moz_places.url NOT NULL
+        ORDER BY moz_bookmarks.dateAdded
+        """
+    )
+    rows = cur.fetchall()
+    con.close()
+
+    lines = [
+        "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+        "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=UTF-8\">",
+        "<TITLE>Bookmarks</TITLE>",
+        "<H1>Bookmarks</H1>",
+        "<DL><p>",
+    ]
+    for url, title in rows:
+        name = title or url
+        lines.append(f"    <DT><A HREF=\"{url}\">{name}</A>")
+    lines.append("</DL><p>")
+    dst_html = output_dir / "firefox_bookmarks.html"
+    dst_html.write_text("\n".join(lines), encoding="utf-8")
+    return dst_html

--- a/browser_exporter/utils.py
+++ b/browser_exporter/utils.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+
+def chrome_json_to_html(data: dict) -> str:
+    """Convert Chrome's bookmark JSON into a simple HTML bookmark file."""
+    header = [
+        "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+        "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=UTF-8\">",
+        "<TITLE>Bookmarks</TITLE>",
+        "<H1>Bookmarks</H1>",
+        "<DL><p>",
+    ]
+
+    lines = []
+
+    def walk(node, indent=1):
+        pad = "    " * indent
+        if node.get("type") == "folder":
+            lines.append(f"{pad}<DT><H3>{node.get('name', '')}</H3>")
+            lines.append(f"{pad}<DL><p>")
+            for child in node.get("children", []):
+                walk(child, indent + 1)
+            lines.append(f"{pad}</DL><p>")
+        elif node.get("type") == "url":
+            href = node.get("url", "")
+            name = node.get("name", href)
+            lines.append(f"{pad}<DT><A HREF=\"{href}\">{name}</A>")
+
+    roots = data.get("roots", {})
+    for root in roots.values():
+        walk(root)
+
+    footer = ["</DL><p>"]
+    return "\n".join(header + lines + footer)
+
+
+def load_chrome_bookmark_json(path: Path) -> dict:
+    with Path(path).open("r", encoding="utf-8") as f:
+        return json.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+from browser_exporter.utils import chrome_json_to_html
+
+
+def test_chrome_json_to_html_basic():
+    data = {
+        "roots": {
+            "bookmark_bar": {
+                "name": "Bookmarks Bar",
+                "type": "folder",
+                "children": [
+                    {"type": "url", "name": "OpenAI", "url": "https://openai.com"}
+                ],
+            }
+        }
+    }
+    html = chrome_json_to_html(data)
+    assert "OpenAI" in html
+    assert "https://openai.com" in html
+    assert "Bookmarks Bar" in html


### PR DESCRIPTION
## Summary
- add utilities to export Chrome, Edge, and Firefox bookmarks and convert them to HTML
- provide CLI entry point to export bookmarks to a chosen folder
- cover basic HTML conversion with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5443b1c64832ea82950b69ba894a4